### PR TITLE
Import CommonModule to avoid issues with lazy loading

### DIFF
--- a/projects/angular2_photoswipe/src/lib/angular2-photoswipe.module.ts
+++ b/projects/angular2_photoswipe/src/lib/angular2-photoswipe.module.ts
@@ -1,4 +1,4 @@
-import { BrowserModule } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { Angular2PhotoswipeComponent } from './angular2-photoswipe.component';
 import { LightboxComponent } from './lightbox/lightbox.component';
@@ -7,7 +7,7 @@ import { GalleryItemComponent } from './gallery-item/gallery-item.component';
 export { LightboxAdapter } from './lightbox-adapter';
 
 @NgModule({
-  imports: [BrowserModule],
+  imports: [CommonModule],
   declarations: [Angular2PhotoswipeComponent, LightboxComponent, GalleryComponent, GalleryItemComponent],
   exports: [LightboxComponent, GalleryComponent, GalleryItemComponent]
 })


### PR DESCRIPTION
See: https://stackoverflow.com/questions/39286667/browsermodule-has-already-been-loaded-error

If you don't need `BrowserModule` for something specific, importing `CommonModule` should suffice for having all the pipes and structural directives without throwing errors when attempting to use the library in lazy-loaded modules.