### PR TITLE
add missing generic argument to fix compilation error

### DIFF
--- a/projects/angular2_photoswipe/src/lib/gallery/gallery.component.ts
+++ b/projects/angular2_photoswipe/src/lib/gallery/gallery.component.ts
@@ -39,7 +39,7 @@ export class GalleryComponent implements AfterContentInit, OnDestroy {
 
   subscriptions: Subscription[] = [];
   isBootstrapEnabled: boolean;
-  pswp: PhotoSwipe;
+  pswp: PhotoSwipe<any>;
 
   images: Image[];
 


### PR DESCRIPTION
TypeScript 4.0.5 complains that Generic type 'PhotoSwipe<T>' requires 1 type argument(s)

This actually fixes #29, which still occurs in `angular2_photoswipe` version `10.0.0`.